### PR TITLE
Set secure defaults for DNS

### DIFF
--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -7,6 +7,10 @@ detectDNS = true
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
 # Format: <IP>::<PORT>::<PROTOCOL>::<URL END POINT>
 # The secure DNS Servers as default below are libredns.gr Nixnet.services uncensoreddns.org
+# Examples below
+# 116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query (Example of DNS-over-HTTPS)
+# 1.1.1.1::853::DoT::cloudflare-dns.com (DNS over TLS, domain name is optional)
+# 176.103.130.130::53::UDP
 
 89.233.43.71::853::DoT
 116.202.176.26::853::DoT
@@ -22,7 +26,7 @@ detectDNS = true
 199.195.251.84::853::DoT
 104.244.78.231::853::DoT
 
-# Fallbacks are from the services adguard.com and libredns.gr
+# Fallbacks are from the services above, and also adguard.com
 fallbackDNS = 176.103.130.130; 176.103.130.131; 116.202.176.26::853::DoT; 116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
 
 # IP Version Support

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -1,7 +1,7 @@
 # detectDNS = true|false.
 # if true, the DNS servers will be detected if possible.
 # if false, the DNS Servers will be taken from the fallbackDNS setting below.
-detectDNS = false
+detectDNS = true
 
 # fallbackDNS - list of DNS servers seperated by ";".
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
@@ -29,8 +29,8 @@ fallbackDNS = 176.103.130.130; 176.103.130.131; 116.202.176.26::853::DoT; 116.20
 ipVersionSupport = 4,6
 
 # Returned IP for resolving blocked host
-ipV4BlockedHost = 127.0.0.1
-ipV6BlockedHost = ::1
+ipV4BlockedHost = 0.0.0.0
+ipV6BlockedHost = ::
 
 # Maximum number of parallel DNS Resolver Connections
 maxResolverCount = 100

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -7,13 +7,14 @@ detectDNS = false
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
 # Format: <IP>::<PORT>::<PROTOCOL>::<URL END POINT>
 # The secure DNS Servers as default below:
-209.141.34.95::853::DoT
-198.251.90.91::853::DoT
-199.195.251.84::853::DoT
-104.244.78.231::853::DoT
-116.202.176.26::853::DoT
-89.233.43.71::853::DoT
-116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
+209.141.34.95::853::DoT #Nixnet.services
+198.251.90.91::853::DoT #Nixnet.services
+199.195.251.84::853::DoT #Nixnet.services
+104.244.78.231::853::DoT #Nixnet.services
+116.202.176.26::853::DoT #libredns.gr
+89.233.43.71::853::DoT #uncensoreddns.org
+116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query #libredns.gr
+# Fallbacks are from the services above also including adguard.com
 fallbackDNS =  91.139.100.100; 89.233.43.71; 192.251.90.91; 209.141.34.95; 176.103.130.130; 176.103.130.131
 
 # IP Version Support

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -7,22 +7,9 @@ detectDNS = false
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
 # Format: <IP>::<PORT>::<PROTOCOL>::<URL END POINT>
 # The secure DNS Servers as default below:
-#libredns.gr
-116.202.176.26::853::DoT
-#uncensoreddns.org
-89.233.43.71::853::DoT
-#libredns.gr
-116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
-#Nixnet.services
-209.141.34.95::853::DoT
-#Nixnet.services
-198.251.90.91::853::DoT
-#Nixnet.services
-199.195.251.84::853::DoT
-#Nixnet.services
-104.244.78.231::853::DoT
-# Fallbacks are from the services above also including adguard.com
-fallbackDNS =  91.139.100.100; 89.233.43.71; 192.251.90.91; 209.141.34.95; 176.103.130.130; 176.103.130.131
+
+# Fallbacks are from the services adguard.com and libredns.gr
+fallbackDNS = 176.103.130.130; 176.103.130.131; 116.202.176.26::853::DoT; 116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
 
 # IP Version Support
 ipVersionSupport = 4,6

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -6,7 +6,21 @@ detectDNS = false
 # fallbackDNS - list of DNS servers seperated by ";".
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
 # Format: <IP>::<PORT>::<PROTOCOL>::<URL END POINT>
-# The secure DNS Servers as default below:
+# The secure DNS Servers as default below are libredns.gr Nixnet.services uncensoreddns.org
+
+89.233.43.71::853::DoT
+116.202.176.26::853::DoT
+116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
+209.141.34.95::853::DoT
+89.233.43.71::853::DoT
+198.251.90.91::853::DoT
+199.195.251.84::853::DoT
+116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
+104.244.78.231::853::DoT
+209.141.34.95::853::DoT
+198.251.90.91::853::DoT
+199.195.251.84::853::DoT
+104.244.78.231::853::DoT
 
 # Fallbacks are from the services adguard.com and libredns.gr
 fallbackDNS = 176.103.130.130; 176.103.130.131; 116.202.176.26::853::DoT; 116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -12,22 +12,8 @@ detectDNS = true
 # 1.1.1.1::853::DoT::cloudflare-dns.com (DNS over TLS, domain name is optional)
 # 176.103.130.130::53::UDP
 
-89.233.43.71::853::DoT
-116.202.176.26::853::DoT
-116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
-209.141.34.95::853::DoT
-89.233.43.71::853::DoT
-198.251.90.91::853::DoT
-199.195.251.84::853::DoT
-116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
-104.244.78.231::853::DoT
-209.141.34.95::853::DoT
-198.251.90.91::853::DoT
-199.195.251.84::853::DoT
-104.244.78.231::853::DoT
-
-# Fallbacks are from the services above, and also adguard.com
-fallbackDNS = 176.103.130.130; 176.103.130.131; 116.202.176.26::853::DoT; 116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
+# Fallbacks are from libredns.gr, uncensoreddns.org, nixnet.services, and also adguard.com
+fallbackDNS = 176.103.130.130; 176.103.130.131; 89.233.43.71::853::DoT; 116.202.176.26::853::DoT; 116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query; 209.141.34.95::853::DoT; 89.233.43.71::853::DoT;  198.251.90.91::853::DoT; 199.195.251.84::853::DoT; 116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query; 104.244.78.231::853::DoT; 209.141.34.95::853::DoT; 198.251.90.91::853::DoT; 199.195.251.84::853::DoT; 104.244.78.231::853::DoT
 
 # IP Version Support
 ipVersionSupport = 4,6

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -7,13 +7,13 @@ detectDNS = false
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
 # Format: <IP>::<PORT>::<PROTOCOL>::<URL END POINT>
 # The secure DNS Servers as default below:
+116.202.176.26::853::DoT #libredns.gr
+89.233.43.71::853::DoT #uncensoreddns.org
+116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query #libredns.gr
 209.141.34.95::853::DoT #Nixnet.services
 198.251.90.91::853::DoT #Nixnet.services
 199.195.251.84::853::DoT #Nixnet.services
 104.244.78.231::853::DoT #Nixnet.services
-116.202.176.26::853::DoT #libredns.gr
-89.233.43.71::853::DoT #uncensoreddns.org
-116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query #libredns.gr
 # Fallbacks are from the services above also including adguard.com
 fallbackDNS =  91.139.100.100; 89.233.43.71; 192.251.90.91; 209.141.34.95; 176.103.130.130; 176.103.130.131
 
@@ -21,8 +21,8 @@ fallbackDNS =  91.139.100.100; 89.233.43.71; 192.251.90.91; 209.141.34.95; 176.1
 ipVersionSupport = 4,6
 
 # Returned IP for resolving blocked host
-ipV4BlockedHost = 0.0.0.0
-ipV6BlockedHost = ::
+ipV4BlockedHost = 127.0.0.1
+ipV6BlockedHost = ::1
 
 # Maximum number of parallel DNS Resolver Connections
 maxResolverCount = 100

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -7,13 +7,20 @@ detectDNS = false
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
 # Format: <IP>::<PORT>::<PROTOCOL>::<URL END POINT>
 # The secure DNS Servers as default below:
-116.202.176.26::853::DoT #libredns.gr
-89.233.43.71::853::DoT #uncensoreddns.org
-116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query #libredns.gr
-209.141.34.95::853::DoT #Nixnet.services
-198.251.90.91::853::DoT #Nixnet.services
-199.195.251.84::853::DoT #Nixnet.services
-104.244.78.231::853::DoT #Nixnet.services
+#libredns.gr
+116.202.176.26::853::DoT
+#uncensoreddns.org
+89.233.43.71::853::DoT
+#libredns.gr
+116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
+#Nixnet.services
+209.141.34.95::853::DoT
+#Nixnet.services
+198.251.90.91::853::DoT
+#Nixnet.services
+199.195.251.84::853::DoT
+#Nixnet.services
+104.244.78.231::853::DoT
 # Fallbacks are from the services above also including adguard.com
 fallbackDNS =  91.139.100.100; 89.233.43.71; 192.251.90.91; 209.141.34.95; 176.103.130.130; 176.103.130.131
 

--- a/app/src/main/assets/dnsfilter.conf
+++ b/app/src/main/assets/dnsfilter.conf
@@ -1,17 +1,20 @@
 # detectDNS = true|false.
 # if true, the DNS servers will be detected if possible.
 # if false, the DNS Servers will be taken from the fallbackDNS setting below.
-detectDNS = true
+detectDNS = false
 
 # fallbackDNS - list of DNS servers seperated by ";".
 # Used in case DNS servers are not detected automatically (either switched off or not possible).
 # Format: <IP>::<PORT>::<PROTOCOL>::<URL END POINT>
-# Cloudflare examples below:
-# 1.1.1.1::53::UDP (Default DNS on UDP port 53 / just 1.1.1.1 will work as well)
-# 1.1.1.1::853::DoT::cloudflare-dns.com (DNS over TLS, domain name is optional)
-# 1.1.1.1::443::DoH::https://cloudflare-dns.com/dns-query
-# The Google DNS Servers as default below:
-fallbackDNS =  8.8.8.8; 8.8.4.4
+# The secure DNS Servers as default below:
+209.141.34.95::853::DoT
+198.251.90.91::853::DoT
+199.195.251.84::853::DoT
+104.244.78.231::853::DoT
+116.202.176.26::853::DoT
+89.233.43.71::853::DoT
+116.202.176.26::443::DoH::https://doh.libredns.gr/dns-query
+fallbackDNS =  91.139.100.100; 89.233.43.71; 192.251.90.91; 209.141.34.95; 176.103.130.130; 176.103.130.131
 
 # IP Version Support
 ipVersionSupport = 4,6
@@ -28,12 +31,12 @@ maxResolverCount = 100
 # This might be usefull in case applications ignore the VPN's DNS and just use an own DNS Server,
 # such as the Googles DNS Servers
 # default = "". Uncomment setting below for using this option.
-# As an example below the list of Google DNS servers for IPV4 and IPV6.
-# routeIPs = 8.8.8.8; 8.8.4.4; 2001:4860:4860::8888; 2001:4860:4860::8844
+# As an example below the list of secure and privacy respecting DNS servers for IPV4 and IPV6.
+# routeIPs = 91.139.100.100; 89.233.43.71; 192.251.90.91; 209.141.34.95; 2001:67c:28a4::; 2a01:3a0:53:53::; 2605:6400:20:e6d::1; 2605:6400:10:80e::1
 
 # AUTOSTART = true|false - used only by Android version.
 # if true android app is started automatically on device boot completed.
-AUTOSTART = false
+AUTOSTART = true
 
 # androidAppWhiteList - Only for Android VPN based version (requires at least Android 5.1).
 # List of applications seperated by "," which should bypass the VPN


### PR DESCRIPTION
I removed the Cloudflare examples along with Google DNS and set secure defaults you can find at privacytools.io. This is better for users who want ad blocking without messing with the finer details and just use the app as is. This will also make sure their DNS queries are sent to privacy respecting servers and defaults to DoT.