### PR TITLE
Added raw mode to edit entries

### DIFF
--- a/app/src/main/java/dnsfilter/android/widget/DNSServerConfigEntrySerializer.java
+++ b/app/src/main/java/dnsfilter/android/widget/DNSServerConfigEntrySerializer.java
@@ -2,55 +2,74 @@ package dnsfilter.android.widget;
 
 import static dnsfilter.android.widget.DNSServerConfigEntry.CHAR_LINE_COMMENTED;
 import static dnsfilter.android.widget.DNSServerConfigEntry.EMPTY_STRING;
+import static dnsfilter.android.widget.DNSServerConfigEntry.ENTRY_PARTS_SEPARATOR;
 import static dnsfilter.android.widget.DNSServerConfigEntry.IP_V6_END_BRACER;
 import static dnsfilter.android.widget.DNSServerConfigEntry.IP_V6_START_BRACER;
-import static dnsfilter.android.widget.DNSServerConfigEntry.ENTRY_PARTS_SEPARATOR;
+
+import java.io.IOException;
 
 public class DNSServerConfigEntrySerializer {
 
-    public DNSServerConfigEntry deserialize(String entry) {
+    private DNSServerConfigEntry deserializeImpl(String entry) {
 
         if (entry == null || entry.isEmpty()) {
             return new DNSServerConfigEntry();
         }
 
         DNSServerConfigEntry newEntry;
+        boolean isActive = !entry.startsWith(CHAR_LINE_COMMENTED);
+        if (!isActive) {
+            entry = entry.replace(CHAR_LINE_COMMENTED, EMPTY_STRING);
+        }
 
+        String shortIpV6 = getShortIPV6(entry);
+        String[] splittedEntry;
+        if (shortIpV6 == null) {
+            splittedEntry = entry.split(ENTRY_PARTS_SEPARATOR, 4);
+        } else {
+            String[] partWithoutIP = entry
+                    .substring(entry.indexOf(IP_V6_END_BRACER))
+                    .split(ENTRY_PARTS_SEPARATOR);
+            if (partWithoutIP.length > 1) {
+                splittedEntry = new String[1 + partWithoutIP.length - 1];
+                splittedEntry[0] = shortIpV6;
+                System.arraycopy(partWithoutIP, 1, splittedEntry, 1, partWithoutIP.length - 1);
+            } else {
+                splittedEntry = new String[1];
+                splittedEntry[0] = shortIpV6;
+            }
+        }
+
+        if (splittedEntry.length == 1) {
+            newEntry = new DNSServerConfigEntry(splittedEntry[0], isActive);
+        } else if (splittedEntry.length == 2) {
+            newEntry = new DNSServerConfigEntry(splittedEntry[0], splittedEntry[1], isActive);
+        } else if (splittedEntry.length == 3) {
+            newEntry = new DNSServerConfigEntry(splittedEntry[0], splittedEntry[1], DNSType.valueOf(splittedEntry[2].toUpperCase()), isActive);
+        } else {
+            newEntry = new DNSServerConfigEntry(splittedEntry[0], splittedEntry[1], DNSType.valueOf(splittedEntry[2].toUpperCase()), splittedEntry[3], isActive);
+        }
+
+        return newEntry;
+    }
+
+    public DNSServerConfigEntry deserializeSafe(String entry) {
+        DNSServerConfigEntry newEntry;
         try {
-            boolean isActive = !entry.startsWith(CHAR_LINE_COMMENTED);
-            if (!isActive) {
-                entry = entry.replace(CHAR_LINE_COMMENTED, EMPTY_STRING);
-            }
-
-            String shortIpV6 = getShortIPV6(entry);
-            String[] splittedEntry;
-            if (shortIpV6 == null) {
-                splittedEntry = entry.split(ENTRY_PARTS_SEPARATOR, 4);
-            } else {
-                String[] partWithoutIP = entry
-                        .substring(entry.indexOf(IP_V6_END_BRACER))
-                        .split(ENTRY_PARTS_SEPARATOR);
-                if (partWithoutIP.length > 1) {
-                    splittedEntry = new String[1 + partWithoutIP.length - 1];
-                    splittedEntry[0] = shortIpV6;
-                    System.arraycopy(partWithoutIP, 1, splittedEntry, 1, partWithoutIP.length - 1);
-                } else {
-                    splittedEntry = new String[1];
-                    splittedEntry[0] = shortIpV6;
-                }
-            }
-
-            if (splittedEntry.length == 1) {
-                newEntry = new DNSServerConfigEntry(splittedEntry[0], isActive);
-            } else if (splittedEntry.length == 2) {
-                newEntry = new DNSServerConfigEntry(splittedEntry[0], splittedEntry[1], isActive);
-            } else if (splittedEntry.length == 3) {
-                newEntry = new DNSServerConfigEntry(splittedEntry[0], splittedEntry[1], DNSType.valueOf(splittedEntry[2].toUpperCase()), isActive);
-            } else {
-                newEntry = new DNSServerConfigEntry(splittedEntry[0], splittedEntry[1], DNSType.valueOf(splittedEntry[2].toUpperCase()), splittedEntry[3], isActive);
-            }
+            newEntry = deserializeImpl(entry);
         } catch (RuntimeException e) {
             newEntry = new DNSServerConfigEntry();
+        }
+
+        return newEntry;
+    }
+
+    public DNSServerConfigEntry deserialize(String entry) throws NotDeserializableException {
+        DNSServerConfigEntry newEntry;
+        try {
+            newEntry = deserializeImpl(entry);
+        } catch (RuntimeException e) {
+            throw new NotDeserializableException("Not possibly to deserialize " + entry);
         }
 
         return newEntry;

--- a/app/src/main/java/dnsfilter/android/widget/NotDeserializableException.java
+++ b/app/src/main/java/dnsfilter/android/widget/NotDeserializableException.java
@@ -1,0 +1,12 @@
+package dnsfilter.android.widget;
+
+public class NotDeserializableException extends Exception{
+
+    public NotDeserializableException() {
+        super();
+    }
+
+    public NotDeserializableException(String message) {
+        super(message);
+    }
+}

--- a/app/src/main/res/layout-night/dnsconfigdialog.xml
+++ b/app/src/main/res/layout-night/dnsconfigdialog.xml
@@ -20,9 +20,21 @@
             android:layout_marginStart="15dp"
             android:layout_marginTop="0dp"
             android:layout_marginEnd="15dp"
+            android:layout_marginBottom="15dp"
             android:button="@drawable/custom_checkbox"
             android:checked="false"
             android:text="@string/manualDNSCheck"
+            android:textColor="#FFFFFF" />
+
+        <dnsfilter.android.PaddedCheckBox
+            android:id="@+id/manualDNSRawModeCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:button="@drawable/custom_switch"
+            android:checked="false"
+            android:singleLine="true"
+            android:text="@string/rawEditMode"
             android:textColor="#FFFFFF" />
 
         <ListView
@@ -34,6 +46,33 @@
             android:dividerHeight="10dp"
             android:fadeScrollbars="false"
             android:smoothScrollbar="true" />
+
+        <HorizontalScrollView
+            android:id="@+id/manualDNSScroll"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="15dp"
+            android:layout_marginBottom="15dp"
+            android:background="#151e27"
+            android:overScrollMode="never"
+            android:padding="10dp"
+            android:scrollbars="none"
+            android:visibility="gone">
+
+            <EditText
+                android:id="@+id/manualDNSEditText"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="#151e27"
+                android:inputType="textMultiLine|textNoSuggestions"
+                android:minWidth="200dp"
+                android:textColor="#FFFFFF"
+                android:textSize="14sp"
+                android:typeface="monospace" />
+
+        </HorizontalScrollView>
+
     </LinearLayout>
 
     <RelativeLayout

--- a/app/src/main/res/layout-night/dnsconfigdialog.xml
+++ b/app/src/main/res/layout-night/dnsconfigdialog.xml
@@ -26,7 +26,7 @@
             android:textColor="#FFFFFF" />
 
         <ListView
-            android:id="@+id/manualDNS"
+            android:id="@+id/manualDNSList"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_margin="6dp"

--- a/app/src/main/res/layout/dnsconfigdialog.xml
+++ b/app/src/main/res/layout/dnsconfigdialog.xml
@@ -34,7 +34,7 @@
             android:button="@drawable/custom_switch"
             android:checked="false"
             android:singleLine="true"
-            android:text="Raw edit mode"
+            android:text="@string/rawEditMode"
             android:textColor="#424242" />
 
         <ListView

--- a/app/src/main/res/layout/dnsconfigdialog.xml
+++ b/app/src/main/res/layout/dnsconfigdialog.xml
@@ -20,20 +20,60 @@
             android:layout_marginStart="15dp"
             android:layout_marginTop="0dp"
             android:layout_marginEnd="15dp"
+            android:layout_marginBottom="15dp"
             android:button="@drawable/custom_checkbox"
             android:checked="false"
             android:text="@string/manualDNSCheck"
             android:textColor="#424242" />
 
+        <dnsfilter.android.PaddedCheckBox
+            android:id="@+id/manualDNSRawModeCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:button="@drawable/custom_switch"
+            android:checked="false"
+            android:singleLine="true"
+            android:text="Raw edit mode"
+            android:textColor="#424242" />
+
         <ListView
-            android:id="@+id/manualDNS"
+            android:id="@+id/manualDNSList"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_margin="6dp"
             android:divider="@drawable/divider_custom"
             android:dividerHeight="10dp"
             android:fadeScrollbars="false"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
             android:smoothScrollbar="true" />
+
+        <HorizontalScrollView
+            android:id="@+id/manualDNSScroll"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="15dp"
+            android:layout_marginBottom="15dp"
+            android:background="#E8EBED"
+            android:overScrollMode="never"
+            android:padding="10dp"
+            android:scrollbars="none"
+            android:visibility="gone">
+
+            <EditText
+                android:id="@+id/manualDNSEditText"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="#E8EBED"
+                android:inputType="textMultiLine|textNoSuggestions"
+                android:minWidth="200dp"
+                android:textColor="#424242"
+                android:textSize="14sp"
+                android:typeface="monospace" />
+
+        </HorizontalScrollView>
 
     </LinearLayout>
 
@@ -44,7 +84,6 @@
         android:layout_weight="0.01"
         android:background="#ffffff"
         android:orientation="vertical">
-
 
         <Button
             android:id="@+id/RestoreDefaultBtn"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,5 @@
   <string name="ipEmptyError">IP should not be empty</string>
   <string name="portEmptyError">port should not be empty</string>
   <string name="editEntry">Edit entry</string>
+  <string name="rawEditMode">Raw edit mode</string>
 </resources>

--- a/app/src/test/java/dnsfilter/android/tests/DNSServerConfigEntrySerializerTest.java
+++ b/app/src/test/java/dnsfilter/android/tests/DNSServerConfigEntrySerializerTest.java
@@ -37,7 +37,7 @@ public class DNSServerConfigEntrySerializerTest {
         }};
 
         for (Map.Entry<String, DNSServerConfigEntry> entry : testResults.entrySet()) {
-            DNSServerConfigEntry deserializationResult = serializer.deserialize(entry.getKey());
+            DNSServerConfigEntry deserializationResult = serializer.deserializeSafe(entry.getKey());
             Assert.assertEquals(entry.getValue(), deserializationResult);
         }
     }


### PR DESCRIPTION
Added support for old style DNS entries list - editing with Edit Text.

### Raw mode screen:
<img src='https://user-images.githubusercontent.com/4568712/192564062-ceb89ce3-dfdc-464c-ac69-526476dd941b.jpg' width ='400'>

### Screen in case of error:
<img src='https://user-images.githubusercontent.com/4568712/192564081-2fd9bdea-29aa-432e-9818-bc1ea55b9dcd.jpg' width ='400'>

### Notes:
1. Now it is not possibly to determine which part of entry string in case of raw mode throw error - need to write special validators.
