### PR TITLE
Feature to keep commented lines in personal dns config list

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:label="personalDNSfilter"
         android:theme="@style/Theme.phttpp.TitleBar"
         android:usesCleartextTraffic="true"
-        android:name="dnsfilter.PersonalDNSFilterApp">
+        android:name=".PersonalDNSFilterApp">
 
         <activity
             android:name=".dnsserverconfig.DNSServerConfigActivity"

--- a/app/src/main/java/dnsfilter/android/PersonalDNSFilterApp.java
+++ b/app/src/main/java/dnsfilter/android/PersonalDNSFilterApp.java
@@ -1,4 +1,4 @@
-package dnsfilter;
+package dnsfilter.android;
 
 import android.app.Application;
 

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigActivity.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigActivity.java
@@ -27,6 +27,8 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
     private ListView manualDNSList;
     private EditText manualDNSEditText;
 
+    private PaddedCheckBox showCommentedLinesCheckbox;
+
     private Button restoreDefaultConfigurationButton;
     private ImageButton applyNewConfigurationButton;
 
@@ -45,6 +47,7 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
         configureRawMode();
         configureRestoreDefaultsButton();
         configureApplyNewConfigurationButton();
+        configureShowCommentedLines();
     }
 
     private void setupActionBar() {
@@ -63,6 +66,7 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
     private void findViews() {
         manualDNSList = findViewById(R.id.manualDNSList);
         manualDNSRawModeCheckbox = findViewById(R.id.manualDNSRawModeCheckbox);
+        showCommentedLinesCheckbox = findViewById(R.id.showCommentedLinesCheckbox);
         manualDNSEditText = findViewById(R.id.manualDNSEditText);
         manualDNSCheck = findViewById(R.id.manualDNSCheck);
         restoreDefaultConfigurationButton = findViewById(R.id.restoreDefaultBtn);
@@ -97,6 +101,16 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
             @Override
             public void onClick(View v) {
                 presenter.onChangedEditModeValue(manualDNSRawModeCheckbox.isChecked(), manualDNSEditText.getText().toString());
+            }
+        });
+    }
+
+    private void configureShowCommentedLines() {
+        presenter.onChangedShowCommentedLinesCheckbox(showCommentedLinesCheckbox.isChecked());
+        showCommentedLinesCheckbox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                presenter.onChangedShowCommentedLinesCheckbox(showCommentedLinesCheckbox.isChecked());
             }
         });
     }
@@ -148,6 +162,8 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
         manualDNSList.setVisibility(View.VISIBLE);
         manualDNSEditText.setVisibility(View.GONE);
         manualDNSEditText.setError(null);
+        showCommentedLinesCheckbox.setVisibility(View.VISIBLE);
+        presenter.onChangedShowCommentedLinesCheckbox(showCommentedLinesCheckbox.isChecked());
     }
 
     @Override
@@ -158,6 +174,7 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
         manualDNSEditText.setText(rawModeText);
         manualDNSList.setVisibility(View.GONE);
         manualDNSEditText.setVisibility(View.VISIBLE);
+        showCommentedLinesCheckbox.setVisibility(View.GONE);
     }
 
     @Override

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigActivity.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigActivity.java
@@ -106,7 +106,6 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
     }
 
     private void configureShowCommentedLines() {
-        presenter.onChangedShowCommentedLinesCheckbox(showCommentedLinesCheckbox.isChecked());
         showCommentedLinesCheckbox.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -182,7 +181,8 @@ public class DNSServerConfigActivity extends Activity implements DNSServerConfig
         presenter.saveState(
                 outState,
                 manualDNSRawModeCheckbox.isChecked(),
-                manualDNSEditText.getText().toString()
+                manualDNSEditText.getText().toString(),
+                showCommentedLinesCheckbox.isChecked()
         );
         super.onSaveInstanceState(outState);
     }

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigPresenterImpl.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigPresenterImpl.java
@@ -15,8 +15,8 @@ import java.util.concurrent.Executors;
 import dnsfilter.ConfigUtil;
 import dnsfilter.ConfigurationAccess;
 import dnsfilter.android.dnsserverconfig.widget.DNSListAdapter;
-import dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntry;
 import dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntrySerializer;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigBaseEntry;
 import dnsfilter.android.dnsserverconfig.widget.NotDeserializableException;
 import util.ExecutionEnvironment;
 
@@ -60,7 +60,7 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
     DNSServerConfigPresenterImpl(DNSServerConfigView view, Context context, Bundle savedInstanceState) {
         this.view = view;
 
-        List<DNSServerConfigEntry> entries = new ArrayList<>();
+        List<DNSServerConfigBaseEntry> entries = new ArrayList<>();
 
         if (savedInstanceState != null) {
             isManualDNSServers = savedInstanceState.getBoolean(SAVE_STATE_DETECT_DNS);
@@ -81,8 +81,8 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
         this.listAdapter = new DNSListAdapter(context, entries, testTasksPool);
     }
 
-    private List<DNSServerConfigEntry> readDNSServerConfigFrom(String source) {
-        List<DNSServerConfigEntry> entries = new ArrayList<>();
+    private List<DNSServerConfigBaseEntry> readDNSServerConfigFrom(String source) {
+        List<DNSServerConfigBaseEntry> entries = new ArrayList<>();
         ConfigUtil config = getConfig();
         if (config != null) {
             assert LINE_SEPARATOR != null;
@@ -109,7 +109,7 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
     public void resetDNSConfigToDefault() {
         try {
             Properties defaultProperties = readDefaultDNSConfig();
-            List<DNSServerConfigEntry> entries = readDNSServerConfigFrom(
+            List<DNSServerConfigBaseEntry> entries = readDNSServerConfigFrom(
                     DNSServerConfigUtils.formatSerializedProperties(defaultProperties.getProperty(FALLBACK_DNS_PROPERTY_NAME, ""))
             );
             view.resetToDefaultMode();
@@ -133,7 +133,7 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
             }
             view.showRawMode(entriesBuilder.toString());
         } else {
-            ArrayList<DNSServerConfigEntry> entries = new ArrayList<>();
+            ArrayList<DNSServerConfigBaseEntry> entries = new ArrayList<>();
             if (rawEntriesToDNSServerEntries(rawModeTextValue, entries)) {
                 listAdapter.clear();
                 listAdapter.addAll(entries);
@@ -216,13 +216,13 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
         return entriesBuilder.toString();
     }
 
-    private boolean rawEntriesToDNSServerEntries(String source, ArrayList<DNSServerConfigEntry> entries) {
+    private boolean rawEntriesToDNSServerEntries(String source, ArrayList<DNSServerConfigBaseEntry> entries) {
         DNSServerConfigEntrySerializer serializer = new DNSServerConfigEntrySerializer();
         String[] dnsEntries = source.split(LINE_SEPARATOR);
         try {
             for (String entry : dnsEntries) {
                 if (!entry.isEmpty()) {
-                    DNSServerConfigEntry deserializedValue = serializer.deserialize(entry);
+                    DNSServerConfigBaseEntry deserializedValue = serializer.deserialize(entry);
                     if (entries != null) {
                         entries.add(deserializedValue);
                     }

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigPresenterImpl.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigPresenterImpl.java
@@ -37,6 +37,7 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
     private static final String ASSETS_FILE_NAME = "dnsfilter.conf";
 
     private static final String SAVE_STATE_DETECT_DNS = "detectDNS";
+    private static final String SAVE_STATE_SHOW_COMMENTED_LINES = "showCommentedLines";
     private static final String SAVE_STATE_DNS_LIST = "fallbackDNS";
     private static final String SAVE_STATE_IS_RAW_MODE = "isRadModeDNS";
 
@@ -79,6 +80,13 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
             }
         }
         this.listAdapter = new DNSListAdapter(context, entries, testTasksPool);
+        if (savedInstanceState != null) {
+            if (savedInstanceState.getBoolean(SAVE_STATE_SHOW_COMMENTED_LINES)) {
+                onChangedShowCommentedLinesCheckbox(true);
+            }
+        } else {
+            onChangedShowCommentedLinesCheckbox(false);
+        }
     }
 
     private List<DNSServerConfigBaseEntry> readDNSServerConfigFrom(String source) {
@@ -167,7 +175,7 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
     }
 
     @Override
-    public void saveState(Bundle outState, boolean isRawMode, String rawModeTextValue) {
+    public void saveState(Bundle outState, boolean isRawMode, String rawModeTextValue, boolean showCommentedLines) {
         outState.putBoolean(SAVE_STATE_DETECT_DNS, isManualDNSServers);
         if (isRawMode) {
             outState.putString(SAVE_STATE_DNS_LIST, rawModeTextValue);
@@ -176,6 +184,7 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
             outState.putString(SAVE_STATE_DNS_LIST, DNSServerEntriesToRawEntries());
             outState.putBoolean(SAVE_STATE_IS_RAW_MODE, false);
         }
+        outState.putBoolean(SAVE_STATE_SHOW_COMMENTED_LINES, showCommentedLines);
     }
 
     @Override
@@ -256,7 +265,7 @@ interface DNSServerConfigPresenter {
 
     void applyNewConfiguration(boolean isRawMode, String rawModeTextValue);
 
-    void saveState(Bundle outState, boolean isRawNode, String rawModeTextValue);
+    void saveState(Bundle outState, boolean isRawNode, String rawModeTextValue, boolean showCommentedLines);
 
     void onDestroy();
 }

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigPresenterImpl.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/DNSServerConfigPresenterImpl.java
@@ -148,6 +148,11 @@ public class DNSServerConfigPresenterImpl implements DNSServerConfigPresenter {
     }
 
     @Override
+    public void onChangedShowCommentedLinesCheckbox(boolean isCommentedLinesVisible) {
+        listAdapter.changeCommentedLinesVisibility(isCommentedLinesVisible);
+    }
+
+    @Override
     public void applyNewConfiguration(boolean isRawMode, String rawModeTextValue) {
         if (isRawMode && !rawEntriesToDNSServerEntries(rawModeTextValue, null)) {
             view.showToast("Raw text is not possibly to convert");
@@ -246,6 +251,8 @@ interface DNSServerConfigPresenter {
     void onChangedEditModeValue(boolean isRawMode, String rawModeTextValue);
 
     void onChangedManualDNSServers(boolean isManualDNSServers);
+
+    void onChangedShowCommentedLinesCheckbox(boolean isCommentedLinesVisible);
 
     void applyNewConfiguration(boolean isRawMode, String rawModeTextValue);
 

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSConfigEntryValidator.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSConfigEntryValidator.java
@@ -4,6 +4,7 @@ package dnsfilter.android.dnsserverconfig.widget;
 import android.content.Context;
 
 import dnsfilter.android.R;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry;
 
 public class DNSConfigEntryValidator {
 

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSListAdapter.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSListAdapter.java
@@ -12,6 +12,7 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
+import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
@@ -61,6 +62,21 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigBaseEntry> imple
         this.progressBarAnim.setRepeatCount(Animation.INFINITE);
 
         this.testTasksPool = executor;
+    }
+
+    public void changeCommentedLinesVisibility(boolean isVisible) {
+        boolean updateList = false;
+        for (int i = 0; i < this.getObjectsCount(); i++) {
+            DNSServerConfigBaseEntry entry = this.getItem(i);
+            if (entry instanceof DNSServerConfigCommentedEntry && ((DNSServerConfigCommentedEntry) entry).isVisible() != isVisible) {
+                ((DNSServerConfigCommentedEntry) entry).setVisible(isVisible);
+                updateList = true;
+            }
+        }
+
+        if (updateList) {
+            this.notifyDataSetChanged();
+        }
     }
 
     @Override
@@ -114,11 +130,14 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigBaseEntry> imple
         return view;
     }
 
-
     private View getCommentView(int position, View convertView, ViewGroup parent) {
         DNSServerConfigCommentedEntry entry = (DNSServerConfigCommentedEntry) getItem(position);
 
         DNSServerCommentEntryViewHolder holder;
+
+        if (!entry.isVisible()) {
+            return new View(this.getContext());
+        }
 
         if (convertView == null || !(convertView.getTag() instanceof DNSServerCommentEntryViewHolder)) {
             convertView = LayoutInflater.from(getContext()).inflate(R.layout.dnsserverconfigentrylistcommentitem, parent, false);

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSListAdapter.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSListAdapter.java
@@ -20,12 +20,14 @@ import android.widget.TextView;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import dnsfilter.DNSServer;
 import dnsfilter.android.R;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigBaseEntry;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigCommentedEntry;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry;
 
-public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implements DNSServerConfigEntryView.EditEventsListener {
+public class DNSListAdapter extends ArrayAdapter<DNSServerConfigBaseEntry> implements DNSServerConfigEntryView.EditEventsListener {
 
     private static final int DEFAULT_DNS_TIMEOUT = 15000;
 
@@ -41,7 +43,7 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
 
     private final DNSServerConfigEntryView dnsServerConfigEntryView;
 
-    public DNSListAdapter(Context context, List<DNSServerConfigEntry> objects, ExecutorService executor) {
+    public DNSListAdapter(Context context, List<DNSServerConfigBaseEntry> objects, ExecutorService executor) {
         super(context, 0, objects);
 
         this.dnsServerConfigEntryView = new DNSServerConfigEntryView(context, this);
@@ -73,6 +75,8 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
     @Override
     public int getItemViewType(int position) {
         if (position > super.getCount() - 1) {
+            return 2;
+        } else if (getItem(position) instanceof DNSServerConfigCommentedEntry) {
             return 1;
         } else {
             return 0;
@@ -82,10 +86,16 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
 
-        if (getItemViewType(position) == 1) {
-            convertView = getAddButton(parent);
-        } else {
-            convertView = getItemView(position, convertView, parent);
+        switch (getItemViewType(position)) {
+            case 2:
+                convertView = getAddButton(parent);
+                break;
+            case 1:
+                convertView = getCommentView(position, convertView, parent);
+                break;
+            case 0:
+                convertView = getItemView(position, convertView, parent);
+                break;
         }
 
         return convertView;
@@ -104,8 +114,31 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
         return view;
     }
 
+
+    private View getCommentView(int position, View convertView, ViewGroup parent) {
+        DNSServerConfigCommentedEntry entry = (DNSServerConfigCommentedEntry) getItem(position);
+
+        DNSServerCommentEntryViewHolder holder;
+
+        if (convertView == null || !(convertView.getTag() instanceof DNSServerCommentEntryViewHolder)) {
+            convertView = LayoutInflater.from(getContext()).inflate(R.layout.dnsserverconfigentrylistcommentitem, parent, false);
+
+            holder = new DNSServerCommentEntryViewHolder();
+            setupNewCommentHolder(holder, convertView);
+            convertView.setTag(holder);
+        } else {
+            holder = (DNSServerCommentEntryViewHolder) convertView.getTag();
+        }
+
+        holder.dnsServerCommentEntry = entry;
+        holder.commentView.setText(entry.toString());
+        convertView.setEnabled(false);
+
+        return convertView;
+    }
+
     private View getItemView(int position, View convertView, ViewGroup parent) {
-        DNSServerConfigEntry entry = getItem(position);
+        DNSServerConfigEntry entry = (DNSServerConfigEntry) getItem(position);
 
         DNSServerConfigEntryViewHolder holder;
 
@@ -157,7 +190,7 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
                                 @Override
                                 public void run() {
                                     entry.setTestResult(new DNSServerConfigTestResult(DNSServerConfigEntryTestState.SUCCESS, result));
-                                     notifyDataSetChanged();
+                                    notifyDataSetChanged();
                                 }
                             });
                         } catch (IOException e) {
@@ -204,8 +237,16 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
         return convertView;
     }
 
+    private void setupNewCommentHolder(DNSServerCommentEntryViewHolder holder, View convertView) {
+        findCommentEntryViews(holder, convertView);
+    }
+
+    private void findCommentEntryViews(DNSServerCommentEntryViewHolder holder, View convertView) {
+        holder.commentView = convertView.findViewById(R.id.commentText);
+    }
+
     private void setupNewViewHolder(DNSServerConfigEntryViewHolder holder, View convertView) {
-        findViews(holder, convertView);
+        findEntryViews(holder, convertView);
 
         holder.editEntryButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -215,7 +256,7 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
         });
     }
 
-    private void findViews(DNSServerConfigEntryViewHolder holder, View convertView) {
+    private void findEntryViews(DNSServerConfigEntryViewHolder holder, View convertView) {
         holder.root = convertView.findViewById(R.id.container);
         holder.protocolView = convertView.findViewById(R.id.protocolText);
         holder.ipView = convertView.findViewById(R.id.ipText);
@@ -303,5 +344,10 @@ public class DNSListAdapter extends ArrayAdapter<DNSServerConfigEntry> implement
                     break;
             }
         }
+    }
+
+    static class DNSServerCommentEntryViewHolder {
+        DNSServerConfigCommentedEntry dnsServerCommentEntry;
+        TextView commentView;
     }
 }

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSServerConfigEntrySerializer.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSServerConfigEntrySerializer.java
@@ -1,23 +1,32 @@
 package dnsfilter.android.dnsserverconfig.widget;
 
-import static dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntry.CHAR_LINE_COMMENTED;
-import static dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntry.EMPTY_STRING;
-import static dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntry.ENTRY_PARTS_SEPARATOR;
-import static dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntry.IP_V6_END_BRACER;
-import static dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntry.IP_V6_START_BRACER;
+import static dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry.CHAR_ENTRY_INACTIVE;
+import static dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry.EMPTY_STRING;
+import static dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry.ENTRY_PARTS_SEPARATOR;
+import static dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry.IP_V6_END_BRACER;
+import static dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry.IP_V6_START_BRACER;
+import static dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigBaseEntry.CHAR_LINE_COMMENTED;
+
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigCommentedEntry;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigBaseEntry;
 
 public class DNSServerConfigEntrySerializer {
 
-    private DNSServerConfigEntry deserializeImpl(String entry) {
+    private DNSServerConfigBaseEntry deserializeImpl(String entry) {
 
         if (entry == null || entry.isEmpty()) {
             return new DNSServerConfigEntry();
         }
 
+        if (entry.startsWith(CHAR_LINE_COMMENTED)) {
+            return new DNSServerConfigCommentedEntry(entry.replaceFirst(CHAR_LINE_COMMENTED, EMPTY_STRING));
+        }
+
         DNSServerConfigEntry newEntry;
-        boolean isActive = !entry.startsWith(CHAR_LINE_COMMENTED);
+        boolean isActive = !entry.startsWith(CHAR_ENTRY_INACTIVE);
         if (!isActive) {
-            entry = entry.replace(CHAR_LINE_COMMENTED, EMPTY_STRING);
+            entry = entry.replaceFirst(CHAR_ENTRY_INACTIVE, EMPTY_STRING);
         }
 
         String shortIpV6 = getShortIPV6(entry);
@@ -51,8 +60,8 @@ public class DNSServerConfigEntrySerializer {
         return newEntry;
     }
 
-    public DNSServerConfigEntry deserializeSafe(String entry) {
-        DNSServerConfigEntry newEntry;
+    public DNSServerConfigBaseEntry deserializeSafe(String entry) {
+        DNSServerConfigBaseEntry newEntry;
         try {
             newEntry = deserializeImpl(entry);
         } catch (RuntimeException e) {
@@ -62,8 +71,8 @@ public class DNSServerConfigEntrySerializer {
         return newEntry;
     }
 
-    public DNSServerConfigEntry deserialize(String entry) throws NotDeserializableException {
-        DNSServerConfigEntry newEntry;
+    public DNSServerConfigBaseEntry deserialize(String entry) throws NotDeserializableException {
+        DNSServerConfigBaseEntry newEntry;
         try {
             newEntry = deserializeImpl(entry);
         } catch (RuntimeException e) {

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSServerConfigEntryView.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/DNSServerConfigEntryView.java
@@ -3,27 +3,15 @@ package dnsfilter.android.dnsserverconfig.widget;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.os.Handler;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.Window;
-import android.view.animation.Animation;
-import android.view.animation.AnimationUtils;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.Spinner;
-import android.widget.TextView;
 
-import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import dnsfilter.DNSServer;
 import dnsfilter.android.R;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry;
 
 public class DNSServerConfigEntryView {
 

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigBaseEntry.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigBaseEntry.java
@@ -1,0 +1,5 @@
+package dnsfilter.android.dnsserverconfig.widget.listitem;
+
+public abstract class DNSServerConfigBaseEntry {
+    public static final String CHAR_LINE_COMMENTED = "#";
+}

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigCommentedEntry.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigCommentedEntry.java
@@ -2,9 +2,19 @@ package dnsfilter.android.dnsserverconfig.widget.listitem;
 
 public class DNSServerConfigCommentedEntry extends DNSServerConfigBaseEntry {
     private String comment;
+    private boolean isVisible;
+
+    public boolean isVisible() {
+        return isVisible;
+    }
+
+    public void setVisible(boolean visible) {
+        isVisible = visible;
+    }
 
     public DNSServerConfigCommentedEntry(String comment) {
         this.comment = comment;
+        this.isVisible = true;
     }
 
     public String getComment() {

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigCommentedEntry.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigCommentedEntry.java
@@ -1,0 +1,22 @@
+package dnsfilter.android.dnsserverconfig.widget.listitem;
+
+public class DNSServerConfigCommentedEntry extends DNSServerConfigBaseEntry {
+    private String comment;
+
+    public DNSServerConfigCommentedEntry(String comment) {
+        this.comment = comment;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    @Override
+    public String toString() {
+        return CHAR_LINE_COMMENTED + comment;
+    }
+}

--- a/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigEntry.java
+++ b/app/src/main/java/dnsfilter/android/dnsserverconfig/widget/listitem/DNSServerConfigEntry.java
@@ -1,16 +1,20 @@
-package dnsfilter.android.dnsserverconfig.widget;
+package dnsfilter.android.dnsserverconfig.widget.listitem;
 
 
 import java.util.Objects;
 
-public class DNSServerConfigEntry {
+import dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntryValidationResult;
+import dnsfilter.android.dnsserverconfig.widget.DNSServerConfigTestResult;
+import dnsfilter.android.dnsserverconfig.widget.DNSType;
+
+public class DNSServerConfigEntry extends DNSServerConfigBaseEntry {
 
     private static final String DEFAULT_IP = "";
     private static final Byte DEFAULT_DNS_SELECTION = 0;
     private static final String DEFAULT_PORT = "53";
     private static final String DEFAULT_ENDPOINT = "";
     private static final Boolean DEFAULT_IS_ACTIVE = true;
-    public static final String CHAR_LINE_COMMENTED = "#";
+    public static final String CHAR_ENTRY_INACTIVE = "~";
     public static final String EMPTY_STRING = "";
     public static final String ENTRY_PARTS_SEPARATOR = "::";
     public static final String SHORTER_IP_V6_SEPARATOR = "::";
@@ -106,7 +110,7 @@ public class DNSServerConfigEntry {
 
     @Override
     public String toString() {
-        return getIsActiveAsCommented(this.isActive)
+        return getIsActiveAsString(this.isActive)
                 + highlightShorterIPv6(this.ip)
                 + ENTRY_PARTS_SEPARATOR
                 + port
@@ -154,11 +158,11 @@ public class DNSServerConfigEntry {
         return Objects.hash(ip, port, protocol, endpoint, isActive, testResult, validationResult);
     }
 
-    public static String getIsActiveAsCommented(boolean isActive) {
+    public static String getIsActiveAsString(boolean isActive) {
         if (isActive) {
             return EMPTY_STRING;
         } else {
-            return CHAR_LINE_COMMENTED;
+            return CHAR_ENTRY_INACTIVE;
         }
     }
 

--- a/app/src/main/res/layout-night/activitydnsserverconfig.xml
+++ b/app/src/main/res/layout-night/activitydnsserverconfig.xml
@@ -37,6 +37,17 @@
             android:text="@string/rawEditMode"
             android:textColor="#FFFFFF" />
 
+        <dnsfilter.android.PaddedCheckBox
+            android:id="@+id/showCommentedLinesCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:button="@drawable/custom_switch"
+            android:checked="false"
+            android:singleLine="true"
+            android:text="@string/showCommentedLines"
+            android:textColor="#FFFFFF" />
+
         <ListView
             android:id="@+id/manualDNSList"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout-night/dnsserverconfigentrylistcommentitem.xml
+++ b/app/src/main/res/layout-night/dnsserverconfigentrylistcommentitem.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/rounded_card"
+    android:enabled="false">
+
+    <TextView
+        android:id="@+id/commentText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="6dp"
+        android:gravity="center_vertical"
+        android:minHeight="48dp"
+        android:textColor="#FFFFFF"
+        android:textSize="14sp"
+        android:typeface="monospace"
+        android:textStyle="italic"/>
+</FrameLayout>

--- a/app/src/main/res/layout-night/dnsserverconfigentrylistcommentitem.xml
+++ b/app/src/main/res/layout-night/dnsserverconfigentrylistcommentitem.xml
@@ -14,6 +14,6 @@
         android:minHeight="48dp"
         android:textColor="#FFFFFF"
         android:textSize="14sp"
-        android:typeface="monospace"
-        android:textStyle="italic"/>
+        android:textStyle="italic"
+        android:typeface="monospace" />
 </FrameLayout>

--- a/app/src/main/res/layout/activitydnsserverconfig.xml
+++ b/app/src/main/res/layout/activitydnsserverconfig.xml
@@ -37,6 +37,17 @@
             android:text="@string/rawEditMode"
             android:textColor="#424242" />
 
+        <dnsfilter.android.PaddedCheckBox
+            android:id="@+id/showCommentedLinesCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:button="@drawable/custom_switch"
+            android:checked="false"
+            android:singleLine="true"
+            android:text="@string/showCommentedLines"
+            android:textColor="#424242" />
+
         <ListView
             android:id="@+id/manualDNSList"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/dnsserverconfigentrylistcommentitem.xml
+++ b/app/src/main/res/layout/dnsserverconfigentrylistcommentitem.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/rounded_card"
+    android:enabled="false">
+
+    <TextView
+        android:id="@+id/commentText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="6dp"
+        android:gravity="center_vertical"
+        android:minHeight="48dp"
+        android:textSize="14sp"
+        android:typeface="monospace"
+        android:textStyle="italic"/>
+</FrameLayout>

--- a/app/src/main/res/layout/dnsserverconfigentrylistcommentitem.xml
+++ b/app/src/main/res/layout/dnsserverconfigentrylistcommentitem.xml
@@ -13,6 +13,6 @@
         android:gravity="center_vertical"
         android:minHeight="48dp"
         android:textSize="14sp"
-        android:typeface="monospace"
-        android:textStyle="italic"/>
+        android:textStyle="italic"
+        android:typeface="monospace" />
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,5 @@
   <string name="editEntry">Edit entry</string>
   <string name="rawEditMode">Raw edit mode</string>
   <string name="serverUnreachable">Server is unreachable</string>
+  <string name="showCommentedLines">Show commented lines</string>
 </resources>

--- a/app/src/test/java/dnsfilter/android/tests/DNSServerConfigEntrySerializerTest.java
+++ b/app/src/test/java/dnsfilter/android/tests/DNSServerConfigEntrySerializerTest.java
@@ -6,18 +6,19 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntry;
 import dnsfilter.android.dnsserverconfig.widget.DNSServerConfigEntrySerializer;
 import dnsfilter.android.dnsserverconfig.widget.DNSType;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigEntry;
+import dnsfilter.android.dnsserverconfig.widget.listitem.DNSServerConfigBaseEntry;
 
 public class DNSServerConfigEntrySerializerTest {
 
     @Test
     public void DNSServerConfigEntryDeserializationTest() {
         DNSServerConfigEntrySerializer serializer = new DNSServerConfigEntrySerializer();
-        HashMap<String, DNSServerConfigEntry> testResults = new HashMap<String, DNSServerConfigEntry>() {{
+        HashMap<String, DNSServerConfigBaseEntry> testResults = new HashMap<String, DNSServerConfigBaseEntry>() {{
             put("127.0.0.1::5354::udp", new DNSServerConfigEntry("127.0.0.1", "5354", DNSType.UDP, true));
-            put("#127.0.0.1::5354::udp", new DNSServerConfigEntry("127.0.0.1", "5354", DNSType.UDP, false));
+            put("~127.0.0.1::5354::udp", new DNSServerConfigEntry("127.0.0.1", "5354", DNSType.UDP, false));
             put("127.0.0.1::5400::UDP", new DNSServerConfigEntry("127.0.0.1", "5400", DNSType.UDP, true));
             put("127.0.0.1::5400::UdP", new DNSServerConfigEntry("127.0.0.1", "5400", DNSType.UDP, true));
             put("174.138.21.128::5003::udp", new DNSServerConfigEntry("174.138.21.128", "5003", DNSType.UDP, true));
@@ -27,17 +28,17 @@ public class DNSServerConfigEntrySerializerTest {
             put("192.53.175.149::443::dot::dot-sg.blahdns.com", new DNSServerConfigEntry("192.53.175.149", "443", DNSType.DOT, "dot-sg.blahdns.com", true));
             put("192.53.175.149::853::dot::dot-sg.blahdns.com", new DNSServerConfigEntry("192.53.175.149", "853", DNSType.DOT, "dot-sg.blahdns.com", true));
             put("[2001:4860:4860::8888]::853::dot::dot-sg.blahdns.com", new DNSServerConfigEntry("2001:4860:4860::8888", "853", DNSType.DOT, "dot-sg.blahdns.com", true));
-            put("#[2001:4860:4860::8888]::853::dot::dot-sg.blahdns.com", new DNSServerConfigEntry("2001:4860:4860::8888", "853", DNSType.DOT, "dot-sg.blahdns.com", false));
+            put("~[2001:4860:4860::8888]::853::dot::dot-sg.blahdns.com", new DNSServerConfigEntry("2001:4860:4860::8888", "853", DNSType.DOT, "dot-sg.blahdns.com", false));
             put("127.0.0.1", new DNSServerConfigEntry("127.0.0.1", "53", DNSType.UDP, true));
-            put("#127.0.0.1", new DNSServerConfigEntry("127.0.0.1", "53", DNSType.UDP, false));
+            put("~127.0.0.1", new DNSServerConfigEntry("127.0.0.1", "53", DNSType.UDP, false));
             put("127.0.0.1::500", new DNSServerConfigEntry("127.0.0.1", "500", DNSType.UDP, true));
-            put("#127.0.0.1::500::dot", new DNSServerConfigEntry("127.0.0.1", "500", DNSType.DOT, false));
+            put("~127.0.0.1::500::dot", new DNSServerConfigEntry("127.0.0.1", "500", DNSType.DOT, false));
             put("", new DNSServerConfigEntry());
-            put("#", new DNSServerConfigEntry("", false));
+            put("~", new DNSServerConfigEntry("", false));
         }};
 
-        for (Map.Entry<String, DNSServerConfigEntry> entry : testResults.entrySet()) {
-            DNSServerConfigEntry deserializationResult = serializer.deserializeSafe(entry.getKey());
+        for (Map.Entry<String, DNSServerConfigBaseEntry> entry : testResults.entrySet()) {
+            DNSServerConfigBaseEntry deserializationResult = serializer.deserializeSafe(entry.getKey());
             Assert.assertEquals(entry.getValue(), deserializationResult);
         }
     }


### PR DESCRIPTION
- Added feature to keep commented lines in object-typed dns entries list.
- Moved APP class into android package.

Now all commented lines begin with "#" and inactive with "~".
Also added checkbox to show commented line in a list of entries.