### PR TITLE
Log summary mode added

### DIFF
--- a/app/src/main/res/layout-night/main.xml
+++ b/app/src/main/res/layout-night/main.xml
@@ -740,19 +740,42 @@
 
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/scrolllock"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="15dp"
-            android:layout_marginStart="0dp"
-            android:layout_marginTop="0dp"
-            android:layout_marginEnd="0dp"
-            android:layout_marginBottom="2dp"
-            android:includeFontPadding="false"
-            android:background="#1d2733"
-            android:gravity="end"
-            android:textColor="#FFFFFF"
-            android:textStyle="bold" />
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/logMode"
+                android:layout_width="0dp"
+                android:layout_height="15dp"
+                android:layout_weight="1"
+                android:layout_marginStart="0dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginEnd="0dp"
+                android:layout_marginBottom="2dp"
+                android:includeFontPadding="false"
+                android:background="#1d2733"
+                android:gravity="start"
+                android:textColor="#FFFFFF"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/scrolllock"
+                android:layout_width="0dp"
+                android:layout_height="15dp"
+                android:layout_weight="1"
+                android:layout_marginStart="0dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginEnd="0dp"
+                android:layout_marginBottom="2dp"
+                android:includeFontPadding="false"
+                android:background="#1d2733"
+                android:gravity="end"
+                android:textColor="#FFFFFF"
+                android:textStyle="bold"/>
+        
+        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/copyfromlog"

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -738,19 +738,42 @@
 
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/scrolllock"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="15dp"
-            android:layout_marginStart="0dp"
-            android:layout_marginTop="0dp"
-            android:layout_marginEnd="0dp"
-            android:layout_marginBottom="2dp"
-            android:includeFontPadding="false"
-            android:background="#ffffff"
-            android:gravity="end"
-            android:textColor="#424242"
-            android:textStyle="bold" />
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/logMode"
+                android:layout_width="0dp"
+                android:layout_height="15dp"
+                android:layout_weight="1"
+                android:layout_marginStart="0dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginEnd="0dp"
+                android:layout_marginBottom="2dp"
+                android:includeFontPadding="false"
+                android:background="#ffffff"
+                android:gravity="start"
+                android:textColor="#424242"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/scrolllock"
+                android:layout_width="0dp"
+                android:layout_height="15dp"
+                android:layout_weight="1"
+                android:layout_marginStart="0dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginEnd="0dp"
+                android:layout_marginBottom="2dp"
+                android:includeFontPadding="false"
+                android:background="#ffffff"
+                android:gravity="end"
+                android:textColor="#424242"
+                android:textStyle="bold" />
+        
+        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/copyfromlog"


### PR DESCRIPTION
This PR adds a small log mode button which switches between the actual log and a summary of blocked/allowed 2nd-level domains.

Screenshot:
![photo_2024-04-12_23-03-15](https://github.com/IngoZenz/personaldnsfilter/assets/6472545/5a497c27-71e6-4f51-8858-721dca26c269)
