### PR TITLE
add missing space after colon in "Adding routes" log message

### DIFF
--- a/app/src/main/java/dnsfilter/android/DNSFilterService.java
+++ b/app/src/main/java/dnsfilter/android/DNSFilterService.java
@@ -596,7 +596,7 @@ public class DNSFilterService extends VpnService  {
 		}
 
 		if (!routes.trim().equals("") && !routes.trim().equals(";"))
-			Logger.getLogger().logLine("Adding routes:" + routes);
+			Logger.getLogger().logLine("Adding routes: " + routes);
 
 		StringTokenizer routeIPs = new StringTokenizer(routes, ";");
 


### PR DESCRIPTION
Previously, the log output for "Adding routes" omitted the space after the colon, resulting in lines like:

`Adding routes:8.8.8.8`

This commit adds a space after the colon to improve readability and match the style of the configuration file, so log entries now appear as:

`Adding routes: 8.8.8.8`

---
https://t.me/pDNSf/76759