### PR TITLE
Add missing space after the configurable Proxy Port on Android

### DIFF
--- a/app/src/main/java/dnsfilter/android/DNSFilterService.java
+++ b/app/src/main/java/dnsfilter/android/DNSFilterService.java
@@ -850,7 +850,7 @@ public class DNSFilterService extends VpnService  {
 		if (!DNS_PROXY_PORT_IS_REDIRECTED)
 			return;
 		try {
-			runOSCommand(false, "iptables -t nat -D PREROUTING -p udp --dport 53 -j REDIRECT --to-port"+dnsProxyPort);
+			runOSCommand(false, "iptables -t nat -D PREROUTING -p udp --dport 53 -j REDIRECT --to-port "+dnsProxyPort);
 			DNS_PROXY_PORT_IS_REDIRECTED = false;
 		} catch (Exception e) {
 			Logger.getLogger().logLine("Exception when clearing port redirection:" + e.toString());


### PR DESCRIPTION
Ref: https://github.com/IngoZenz/personaldnsfilter/commit/60620462d3638db585c6aed0997ad8fe86f728#diff-185c32c9bdcd88d17db770d823de04e8a7c115fae41b9f2bb1d09f80d3d31f2bR853
Fix: #349